### PR TITLE
incorrect counter for image names (fixes ffb41ab)

### DIFF
--- a/motion_src/src/motion_detection.cpp
+++ b/motion_src/src/motion_detection.cpp
@@ -36,7 +36,7 @@ inline void directoryExistsOrCreate(const char* pzPath)
 // When motion is detected we write the image to disk
 //    - Check if the directory exists where the image will be stored.
 //    - Build the directory and image names.
-inline bool saveImg(Mat image, const char *DIRECTORY, int img_id, const string EXTENSION, int cropped)
+inline bool saveImg(Mat image, const char *DIRECTORY, int saved_counter, const string EXTENSION, int cropped)
 {
     stringstream ss;
 
@@ -48,7 +48,7 @@ inline bool saveImg(Mat image, const char *DIRECTORY, int img_id, const string E
     directoryExistsOrCreate(ss.str().c_str());
 
     // Create name for the image
-    ss << "/img" << static_cast<int>(img_id) << EXTENSION;
+    ss << "/img" << static_cast<int>(saved_counter) << EXTENSION;
     printf("Saving to %s\n",ss.str().c_str()); fflush(stdout);
     return imwrite(ss.str().c_str(), image);
 }
@@ -132,7 +132,7 @@ int main (int argc, char * const argv[])
     // number_of_changes, the amount of changes in the result matrix.
     // color, the color for drawing the rectangle when something has changed.
     Mat d1, d2, motion;
-    int number_of_changes, number_of_sequence = 0;
+    int number_of_changes, number_of_sequence = 0, saved_counter = 0;
     Scalar mean_, color(0,255,255); // yellow
     
 
@@ -184,8 +184,9 @@ int main (int argc, char * const argv[])
         if(number_of_changes>=there_is_motion)
         {
             if(number_of_sequence>0){ 
-                saveImg(result,argv[2],number_of_sequence,EXT,0);
-                saveImg(result_cropped,argv[2],number_of_sequence,EXT,1);
+                saveImg(result,argv[2],saved_counter,EXT,0);
+                saveImg(result_cropped,argv[2],saved_counter,EXT,1);
+                saved_counter++;
             }
             number_of_sequence++;
         }


### PR DESCRIPTION
Big whoops in the last PR!

`number_of_sequence` counts the number of the image in the _current_ sequence of changes, hence it gets reset often. This means that images were eventually overwritten.
